### PR TITLE
Add support for the hosting provider Render.com

### DIFF
--- a/packages/next-deploy-notifications/src/api/has-new-deploy.ts
+++ b/packages/next-deploy-notifications/src/api/has-new-deploy.ts
@@ -21,6 +21,9 @@ let findGitRoot = (path = __dirname): string | false => {
 let isVercel: IsEnvironment = () => !!process.env.VERCEL;
 let getVercelVersion: GetVersion = () => `${process.env.VERCEL_GIT_COMMIT_SHA}`;
 
+let isRender: IsEnvironment = () => !!process.env.RENDER;
+let getRenderVersion: GetVersion = () => `${process.env.RENDER_GIT_COMMIT}`;
+
 let isGit: IsEnvironment = () => !!findGitRoot();
 let getGitVersion: GetVersion = async () => {
   let root = findGitRoot();
@@ -60,6 +63,8 @@ let makeRouteHandler = (options: Options = {}): Handler => {
       ? options.version()
       : isVercel()
       ? getVercelVersion()
+      : isRender()
+      ? getRenderVersion()
       : isGit()
       ? getGitVersion()
       : getUnknownVersion();

--- a/packages/next-deploy-notifications/vite.config.ts
+++ b/packages/next-deploy-notifications/vite.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
   define: {
     "process.env.VERCEL": "process.env.VERCEL",
     "process.env.VERCEL_GIT_COMMIT_SHA": "process.env.VERCEL_GIT_COMMIT_SHA",
+    "process.env.RENDER": "process.env.RENDER",
+    "process.env.RENDER_GIT_COMMIT": "process.env.RENDER_GIT_COMMIT",
   },
   build: {
     lib: {


### PR DESCRIPTION
## This PR adds support for [Render.com](https://render.com).

When deployed to a Render environment, this package will now identify the current version by looking for `RENDER` and `RENDER_GIT_COMMIT` environment variables. All Render environments expose the `RENDER` variable as `true` and the `RENDER_GIT_COMMIT` will be the latest git commit hash for the given deploy.

Let me know if I can do anything else to help out. I've never developed/contributed to a TS library before so I may have missed something important. 

Cheers

